### PR TITLE
【issue#12】ルームの一秒待ち処理の改善

### DIFF
--- a/game/observer.go
+++ b/game/observer.go
@@ -33,6 +33,20 @@ func (observer *Observer) Close(){
 	}
 }
 
+func (observer *Observer) Join(ClientId int, Connection net.Conn, UserName string, Rate int) {
+    observer.Senders = appendSender(ClientId, Connection, observer.Senders)
+    observer.UserNames[ClientId] = UserName
+    observer.UserRates[ClientId] = Rate
+	fmt.Printf("%d:%s:%d Join, now menber count is %d\n", ClientId,observer.UserNames[ClientId], observer.UserRates[ClientId], len(observer.Senders))
+    message:=map[string]interface{}{}
+    message["messageType"]="Wait"
+    message["nowWaitingPlayer"]=len(observer.Senders)
+	for i := range observer.Senders {
+		observer.Senders[i].SendMessage(message)
+	}
+
+}
+
 func (observer *Observer) WaitNotice() {
     notice := <-observer.Subject
 
@@ -76,20 +90,6 @@ func (observer *Observer) WaitNotice() {
 	}
 
 	break
-
-    case Join:
-        observer.Senders = appendSender(notice.ClientId, notice.Connection, observer.Senders)
-        observer.UserNames[notice.ClientId] = notice.UserName
-        observer.UserRates[notice.ClientId] = notice.Rate
-	    fmt.Printf("%d:%s:%d Join, now menber count is %d\n", notice.ClientId,observer.UserNames[notice.ClientId], observer.UserRates[notice.ClientId], len(observer.Senders))
-        message:=map[string]interface{}{}
-        message["messageType"]="Wait"
-        message["nowWaitingPlayer"]=len(observer.Senders)
-		for i := range observer.Senders {
-			observer.Senders[i].SendMessage(message)
-		}
-
-        break
 
     case Defect:
 	    if observer.Status==Wait{

--- a/game/receiver.go
+++ b/game/receiver.go
@@ -11,10 +11,10 @@ type Receiver struct {
     Observer chan<- Notification
 }
 
-func (receiver *Receiver) Start(userName string ,rate int) {
-	receiver.Observer <- Notification{ Type: Join, ClientId: receiver.Id, Connection: receiver.Connection ,UserName: userName,Rate:rate}
-	receiver.WaitMessage();
-}
+//func (receiver *Receiver) Start(userName string ,rate int) {
+//	receiver.Observer <- Notification{ Type: Join, ClientId: receiver.Id, Connection: receiver.Connection ,UserName: userName,Rate:rate}
+//	receiver.WaitMessage();
+//}
 
 func (receiver *Receiver) WaitMessage() {
     var buf = make([]byte, 1024);

--- a/game/room.go
+++ b/game/room.go
@@ -3,7 +3,6 @@ package game
 import (
     "fmt"
     "net"
-    "time"
 )
 
 type Room struct {
@@ -30,15 +29,16 @@ func NewRoom(roomId int) *Room {
 }
 
 //I will be passing the UUID to the sequence variable in the future.
-// variable name "sequence" is change at that time.
+// variable name "sequence" is change at that ime.
 func (room *Room)UserJoin(sequence int, connection net.Conn,userName string,rate int) {
     var receiver Receiver = Receiver{ Id: len(room.Observers.Senders), Connection: connection, Observer: room.Channel }
-    go receiver.Start(userName,rate)
+    room.Observers.Join(receiver.Id, connection, userName, rate)
+    go receiver.WaitMessage()
 
     //Wait for the add sender.
-	time.Sleep(time.Second * 1)
+	//time.Sleep(time.Second * 1)
     //The game starts as soon as 4 members have gathered
-    if 4 == len(room.Observers.Senders) {
+    if 4 <= len(room.Observers.Senders) {
         room.Channel <- Notification{Type: InitGame}
         //For debugging
         fmt.Println(room.Observers.Game)


### PR DESCRIPTION
同期的にしたい処理まで非同期でまとめて行っていたのでその部分を修正しました。結果的に無理矢理sleepしていた部分が消せたので問題は解消しました。