### PR TITLE
【issue#24】dockerのコンテナが落ちたときに自動的に再起動

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
         tty: true
         volumes:
             - .:/go/src/go_server
+        restart: unless_stopped
 
     app2:
         ports:
@@ -15,6 +16,7 @@ services:
         tty: true
         volumes:
             - .:/go/src/go_server
+        restart: unless_stopped
     
     proxy:
         build: ./proxy
@@ -22,4 +24,5 @@ services:
             - app:app
             - app2:app2
         ports:
-            - 1234:1234
+            - 1234:1234 
+        restart: unless_stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
         tty: true
         volumes:
             - .:/go/src/go_server
-        restart: unless_stopped
+        restart: unless-stopped
 
     app2:
         ports:
@@ -16,7 +16,7 @@ services:
         tty: true
         volumes:
             - .:/go/src/go_server
-        restart: unless_stopped
+        restart: unless-stopped
     
     proxy:
         build: ./proxy
@@ -25,4 +25,4 @@ services:
             - app2:app2
         ports:
             - 1234:1234 
-        restart: unless_stopped
+        restart: unless-stopped

--- a/startup.sh
+++ b/startup.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker-compose up -d --build --scale app=2


### PR DESCRIPTION
restart: unless-stoppedで対応した。
ついでにコマンド打つのが面倒なので起動コマンドをshellscriptにした。