### PR TITLE
【issue#23】dockerコンテナのUserがrootなのを変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM golang:latest
 
+ARG UID=1001
+RUN useradd -m -u ${UID} docker
+
+USER ${UID}
+
 RUN mkdir /go/src/go_server
 
 WORKDIR /go/src/go_server


### PR DESCRIPTION
goのdocker imageがroot実行されていたので非rootユーザで実行するように変更した。
nginxのdocker imageは実行時にnginxユーザが作成され、
nginxユーザが実行したことになるので変更を加えずともrootでの実行にはなっていない（はず）。